### PR TITLE
Issue自動選定スキルと監視スクリプトの拡張

### DIFF
--- a/.claude/agents/issue-assigner.md
+++ b/.claude/agents/issue-assigner.md
@@ -1,0 +1,43 @@
+---
+name: issue-assigner
+description: open状態のIssueを優先度順に評価し、上位2件に assign-to-claude ラベルを付与する専用エージェント。
+tools: Bash(gh issue list *), Bash(gh issue view *), Bash(gh issue edit *)
+model: sonnet
+---
+
+# Issue自動選定エージェント
+
+open状態のIssueを優先度順に評価し、上位2件に `assign-to-claude` ラベルを付与する。
+
+## ワークフロー
+
+1. **Issue一覧の取得**
+   - `gh issue list --state open --json number,title,labels,body,createdAt --limit 100` でopen状態のIssue一覧を取得
+   - 既に `assign-to-claude` または `in-progress-by-claude` ラベルが付いているIssueは除外
+
+2. **優先度判定**
+   - 各Issueの内容（タイトル、本文、ラベル）を確認し、優先度を判定
+   - 優先度ルールに従って並び替え
+
+3. **ラベル付与**
+   - 優先度が高い上位2件に `assign-to-claude` ラベルを付与
+   - `gh issue edit {number} --add-label "assign-to-claude"` で付与
+   - 対象が1件以下の場合は存在する分だけ付与（0件なら何もしない）
+
+4. **結果報告**
+   - ラベルを付与したIssue番号とタイトル、判定理由を出力
+
+## 優先度判定ロジック
+
+| 優先度 | 条件 | 例 |
+|---|---|---|
+| **P1（最優先）** | アプリケーションの正常系動作ができなくなるような緊急対応が必要なバグ修正 | クラッシュ、データ損失、主要機能の完全停止 |
+| **P2（次に優先）** | `.claude` 配下のファイルに関する改修 | スキル追加・修正、スクリプト改修、設定変更 |
+| **P3（通常）** | 上記以外のすべてのIssue | 新機能、リファクタリング、ドキュメント改善 |
+
+### 判定基準の詳細
+
+- **P1の判定**: Issueのタイトル・本文・ラベル（`bug` ラベルの有無）から、正常系動作に致命的影響があるバグかどうかを判断する。単なるバグではなく「アプリケーションの正常系動作が不能になるレベル」のもののみP1とする。
+- **P2の判定**: Issueのタイトル・本文に `.claude` 配下のファイルへの言及があるか、または実装内容が `.claude` 配下に限定されるかを判断する。
+- **P3**: P1・P2に該当しないもの。
+- **同一優先度内の並び順**: `createdAt`（Issue作成日時）が古いものを優先する。

--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# オプション解析
+USE_PRINT_MODE=false
+while getopts "p" opt; do
+  case "$opt" in
+    p) USE_PRINT_MODE=true ;;
+    *) echo "Usage: $0 [-p]" >&2; exit 1 ;;
+  esac
+done
+
+echo "Issue自動選定を開始します"
+
+# Claudeでissueを選定・ラベル付与（コード変更不要のため--worktreeは不使用）
+if "${USE_PRINT_MODE}"; then
+  claude --dangerously-skip-permissions -p "/assign-issues"
+else
+  claude --dangerously-skip-permissions "/assign-issues"
+fi

--- a/.claude/scripts/watch-empty-queue.sh
+++ b/.claude/scripts/watch-empty-queue.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INTERVAL_SECONDS=60
+waiting=false
+
+# Ctrl-C（SIGINT）で正常終了するためのトラップ
+SCRIPT_DIR=$(dirname "$0")
+
+trap 'if [ "$waiting" = true ]; then echo ""; fi; echo "Stopping watch-empty-queue.sh..."; exit 0' INT
+
+while true; do
+  # assign-to-claudeラベル付きopen Issueの件数を確認
+  queue_count=$(gh issue list \
+    --label "assign-to-claude" \
+    --state open \
+    --json number \
+    --jq 'length')
+
+  if [ "$queue_count" -eq 0 ]; then
+    # キュー空の場合: 待機状態をリセットして自動選定を実行
+    if [ "$waiting" = true ]; then
+      echo ""
+      waiting=false
+    fi
+
+    echo "----------------------------------------"
+    echo "Queue is empty. Running assign-issues..."
+    echo "----------------------------------------"
+
+    "${SCRIPT_DIR}/assign-issues.sh" -p || true
+  else
+    # キューにIssueがある場合
+    if [ "$waiting" = false ]; then
+      printf "Waiting for queue to be empty..."
+      waiting=true
+    else
+      printf "."
+    fi
+  fi
+
+  # 一定時間待機
+  sleep "$INTERVAL_SECONDS"
+done

--- a/.claude/scripts/watch-queued-issues.sh
+++ b/.claude/scripts/watch-queued-issues.sh
@@ -5,7 +5,7 @@ INTERVAL_SECONDS=60
 waiting=false
 
 # Ctrl-C（SIGINT）で正常終了するためのトラップ
-trap 'if [ "$waiting" = true ]; then echo ""; fi; echo "Stopping watch-issue.sh..."; exit 0' INT
+trap 'if [ "$waiting" = true ]; then echo ""; fi; echo "Stopping watch-queued-issues.sh..."; exit 0' INT
 
 while true; do
   # assign-to-claudeラベル付き、かつin-progress-by-claudeラベルが付いていないissueを1件取得（古い順）

--- a/.claude/skills/assign-issues/SKILL.md
+++ b/.claude/skills/assign-issues/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: assign-issues
+description: open状態のIssueを優先度順に評価し、上位2件に assign-to-claude ラベルを付与する。
+context: fork
+agent: issue-assigner
+disable-model-invocation: false
+user-invocable: true
+---
+
+open状態のIssueを確認し、優先度に基づいてラベルを付与してください。


### PR DESCRIPTION
## Summary

- `.claude/agents/issue-assigner.md` を新規作成: open状態のIssueを優先度順（P1/P2/P3）に評価し、上位2件に `assign-to-claude` ラベルを付与するカスタムサブエージェント
- `.claude/skills/assign-issues/SKILL.md` を新規作成: `context: fork` + `agent: issue-assigner` でサブエージェントに処理を委譲するスキル定義
- `.claude/scripts/assign-issues.sh` を新規作成: `-p` オプション対応のスキル呼び出しスクリプト
- `.claude/scripts/watch-empty-queue.sh` を新規作成: `assign-to-claude` ラベル付きIssueが0件になったら自動選定を実行する監視ループ
- `watch-issue.sh` → `watch-queued-issues.sh` にリネーム（トラップメッセージも新ファイル名に修正）

## Test plan

- [ ] `.claude/agents/issue-assigner.md` が作成され、優先度判定ロジック（P1/P2/P3）が定義されていること
- [ ] `.claude/agents/issue-assigner.md` の `tools` がgh issue操作のみに制限されていること
- [ ] `.claude/skills/assign-issues/SKILL.md` が作成され、`context: fork` + `agent: issue-assigner` の構成であること
- [ ] `.claude/scripts/assign-issues.sh` が作成され、`-p` オプションで出力モードを切り替えられること
- [ ] `.claude/scripts/watch-empty-queue.sh` が作成され、キュー空の監視ループが記述されていること
- [ ] `.claude/scripts/watch-issue.sh` が `.claude/scripts/watch-queued-issues.sh` にリネームされていること
- [ ] リネーム後のトラップメッセージが新ファイル名を反映していること

Closes #20

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)