### PR TITLE
retroスキルの振り返り対象表現を改善 #21

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retro
-description: 作業セッションを振り返り、改善点を分析してGitHub Issueを作成します。会話セッション終了時に使用してください。
+description: 直前の作業内容を振り返り、改善点を分析してGitHub Issueを作成します。作業完了後に使用してください。
 context: fork
 agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash(gh issue create *), Bash(gh issue list *)
@@ -10,7 +10,7 @@ user-invocable: true
 
 振り返りを行います。
 
-1. 会話セッションでの作業内容を振り返る
+1. 直前の作業内容を振り返る
   - 実施タスク
   - 使用したスキル/エージェント
   - スムーズだった点


### PR DESCRIPTION
## Summary
- retroスキルの「会話セッションでの作業内容を振り返る」という曖昧な表現を「直前の作業内容を振り返る」に変更
- descriptionの「会話セッション終了時に使用」を「作業完了後に使用」に変更

## 変更ファイル
- `.claude/skills/retro/SKILL.md`

## Test plan
- [ ] retroスキル実行時に直前の作業内容が正しく振り返り対象として認識されることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)