### PR TITLE
GitHub APIクライアント -- Issue一覧取得 #6

### DIFF
--- a/internal/domain/entity/issue.go
+++ b/internal/domain/entity/issue.go
@@ -1,0 +1,26 @@
+package entity
+
+import "time"
+
+// IssueState はIssueの状態を表す。
+type IssueState string
+
+const (
+	// IssueStateOpen はオープン状態のIssue。
+	IssueStateOpen IssueState = "open"
+	// IssueStateClosed はクローズ状態のIssue。
+	IssueStateClosed IssueState = "closed"
+)
+
+// Issue はGitHubのIssueを表すエンティティ。
+type Issue struct {
+	Number    int
+	Title     string
+	State     IssueState
+	Author    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ClosedAt  *time.Time
+	URL       string
+	Labels    []string
+}

--- a/internal/domain/entity/issue_test.go
+++ b/internal/domain/entity/issue_test.go
@@ -1,0 +1,102 @@
+package entity
+
+import (
+	"testing"
+	"time"
+)
+
+// === テストリスト ===
+// DONE: IssueState の値が正しい（open, closed）
+// DONE: Issue構造体に期待フィールドが設定できる
+// DONE: Issue の ClosedAt が nil の場合（オープンIssue）
+// DONE: Issue の Labels が空の場合
+
+func TestIssueState_Values(t *testing.T) {
+	tests := []struct {
+		state IssueState
+		want  string
+	}{
+		{IssueStateOpen, "open"},
+		{IssueStateClosed, "closed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if string(tt.state) != tt.want {
+				t.Errorf("IssueState = %q, want %q", tt.state, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssue_HasExpectedFields(t *testing.T) {
+	now := time.Now()
+	closedAt := now.Add(-1 * time.Hour)
+	issue := Issue{
+		Number:    42,
+		Title:     "テストIssue",
+		State:     IssueStateClosed,
+		Author:    "testuser",
+		CreatedAt: now,
+		UpdatedAt: now,
+		ClosedAt:  &closedAt,
+		URL:       "https://github.com/owner/repo/issues/42",
+		Labels:    []string{"bug", "high-priority"},
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("Number = %d, want 42", issue.Number)
+	}
+	if issue.Title != "テストIssue" {
+		t.Errorf("Title = %q, want %q", issue.Title, "テストIssue")
+	}
+	if issue.State != IssueStateClosed {
+		t.Errorf("State = %q, want %q", issue.State, IssueStateClosed)
+	}
+	if issue.Author != "testuser" {
+		t.Errorf("Author = %q, want %q", issue.Author, "testuser")
+	}
+	if !issue.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt not set correctly")
+	}
+	if !issue.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt not set correctly")
+	}
+	if issue.ClosedAt == nil || !issue.ClosedAt.Equal(closedAt) {
+		t.Errorf("ClosedAt not set correctly")
+	}
+	if issue.URL != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("URL = %q, want %q", issue.URL, "https://github.com/owner/repo/issues/42")
+	}
+	if len(issue.Labels) != 2 || issue.Labels[0] != "bug" || issue.Labels[1] != "high-priority" {
+		t.Errorf("Labels = %v, want [bug high-priority]", issue.Labels)
+	}
+}
+
+func TestIssue_ClosedAtNil(t *testing.T) {
+	issue := Issue{
+		Number:    1,
+		Title:     "オープンIssue",
+		State:     IssueStateOpen,
+		Author:    "testuser",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		ClosedAt:  nil,
+		URL:       "https://github.com/owner/repo/issues/1",
+	}
+
+	if issue.ClosedAt != nil {
+		t.Error("ClosedAt should be nil for open issue")
+	}
+}
+
+func TestIssue_EmptyLabels(t *testing.T) {
+	issue := Issue{
+		Number: 1,
+		Labels: []string{},
+	}
+
+	if len(issue.Labels) != 0 {
+		t.Errorf("Labels should be empty, got %v", issue.Labels)
+	}
+}

--- a/internal/domain/github.go
+++ b/internal/domain/github.go
@@ -13,8 +13,17 @@ type ListPullRequestsOptions struct {
 	Status entity.PRState
 }
 
+// ListIssuesOptions はIssue一覧取得のオプション。
+type ListIssuesOptions struct {
+	Since   *time.Time
+	Status  entity.IssueState
+	Numbers []int
+}
+
 // GitHubRepository はGitHub APIへのアクセスを抽象化するインターフェース。
 type GitHubRepository interface {
 	// ListPullRequests は指定リポジトリのPR一覧を取得する。
 	ListPullRequests(ctx context.Context, owner, repo string, opts ListPullRequestsOptions) ([]entity.PullRequest, error)
+	// ListIssues は指定リポジトリのIssue一覧を取得する。
+	ListIssues(ctx context.Context, owner, repo string, opts ListIssuesOptions) ([]entity.Issue, error)
 }

--- a/internal/domain/github_test.go
+++ b/internal/domain/github_test.go
@@ -15,8 +15,31 @@ func (m *mockGitHubRepository) ListPullRequests(ctx context.Context, owner, repo
 	return nil, nil
 }
 
+func (m *mockGitHubRepository) ListIssues(ctx context.Context, owner, repo string, opts ListIssuesOptions) ([]entity.Issue, error) {
+	return nil, nil
+}
+
 func TestGitHubRepository_InterfaceImplementation(t *testing.T) {
 	var _ GitHubRepository = &mockGitHubRepository{}
+}
+
+func TestListIssuesOptions_HasExpectedFields(t *testing.T) {
+	now := time.Now()
+	opts := ListIssuesOptions{
+		Since:   &now,
+		Status:  entity.IssueStateOpen,
+		Numbers: []int{1, 2, 3},
+	}
+
+	if opts.Since == nil || !opts.Since.Equal(now) {
+		t.Error("Since field not set correctly")
+	}
+	if opts.Status != entity.IssueStateOpen {
+		t.Errorf("Status = %q, want %q", opts.Status, entity.IssueStateOpen)
+	}
+	if len(opts.Numbers) != 3 || opts.Numbers[0] != 1 {
+		t.Errorf("Numbers = %v, want [1 2 3]", opts.Numbers)
+	}
 }
 
 func TestListPullRequestsOptions_HasExpectedFields(t *testing.T) {

--- a/internal/infra/github/issues.go
+++ b/internal/infra/github/issues.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+	"github.com/canpok1/github-analyzer/internal/domain/entity"
+	gh "github.com/google/go-github/v68/github"
+)
+
+// ListIssues は指定リポジトリのIssue一覧を取得する。
+func (c *Client) ListIssues(ctx context.Context, owner, repo string, opts domain.ListIssuesOptions) ([]entity.Issue, error) {
+	// Numbers指定がある場合は個別取得
+	if len(opts.Numbers) > 0 {
+		return c.getIssuesByNumbers(ctx, owner, repo, opts.Numbers)
+	}
+
+	apiState := resolveIssueAPIState(opts.Status)
+
+	ghOpts := &gh.IssueListByRepoOptions{
+		State:     apiState,
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: gh.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	if opts.Since != nil {
+		ghOpts.Since = *opts.Since
+	}
+
+	var allIssues []entity.Issue
+
+	for {
+		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repo, ghOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list issues: %w", err)
+		}
+
+		for _, issue := range issues {
+			// go-github の Issues.ListByRepo はPRも返すため除外
+			if issue.IsPullRequest() {
+				continue
+			}
+
+			// Sinceフィルタ: updatedで降順ソート済みのため、Since以前なら以降も全て古い
+			if opts.Since != nil && issue.GetUpdatedAt().Before(*opts.Since) {
+				return allIssues, nil
+			}
+
+			allIssues = append(allIssues, convertIssue(issue))
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		ghOpts.Page = resp.NextPage
+	}
+
+	return allIssues, nil
+}
+
+// getIssuesByNumbers は指定番号のIssueを個別に取得する。
+func (c *Client) getIssuesByNumbers(ctx context.Context, owner, repo string, numbers []int) ([]entity.Issue, error) {
+	issues := make([]entity.Issue, 0, len(numbers))
+
+	for _, num := range numbers {
+		issue, _, err := c.client.Issues.Get(ctx, owner, repo, num)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get issue #%d: %w", num, err)
+		}
+
+		// PRの場合はスキップ
+		if issue.IsPullRequest() {
+			continue
+		}
+
+		issues = append(issues, convertIssue(issue))
+	}
+
+	return issues, nil
+}
+
+// resolveIssueAPIState はIssueStateをGitHub API用のstate値に変換する。
+func resolveIssueAPIState(status entity.IssueState) string {
+	switch status {
+	case entity.IssueStateOpen:
+		return "open"
+	case entity.IssueStateClosed:
+		return "closed"
+	default:
+		return "all"
+	}
+}
+
+// convertIssue はgo-githubのIssueをドメインエンティティに変換する。
+func convertIssue(issue *gh.Issue) entity.Issue {
+	result := entity.Issue{
+		Number: issue.GetNumber(),
+		Title:  issue.GetTitle(),
+		Author: issue.GetUser().GetLogin(),
+		URL:    issue.GetHTMLURL(),
+	}
+
+	if issue.GetState() == "closed" {
+		result.State = entity.IssueStateClosed
+	} else {
+		result.State = entity.IssueStateOpen
+	}
+
+	if issue.CreatedAt != nil {
+		result.CreatedAt = issue.CreatedAt.Time
+	}
+	if issue.UpdatedAt != nil {
+		result.UpdatedAt = issue.UpdatedAt.Time
+	}
+	if issue.ClosedAt != nil {
+		t := issue.ClosedAt.Time
+		result.ClosedAt = &t
+	}
+
+	for _, label := range issue.Labels {
+		result.Labels = append(result.Labels, label.GetName())
+	}
+
+	return result
+}

--- a/internal/infra/github/issues_test.go
+++ b/internal/infra/github/issues_test.go
@@ -1,0 +1,262 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+	"github.com/canpok1/github-analyzer/internal/domain/entity"
+	gh "github.com/google/go-github/v68/github"
+)
+
+// === テストリスト ===
+// DONE: 正常系: Issue一覧を取得できる（PRを除外する）
+// DONE: 正常系: ステータスフィルタ（open）が適用される
+// DONE: 正常系: Sinceフィルタで古いIssueが除外される
+// DONE: 正常系: 空の結果を返す
+// DONE: 異常系: APIエラー時にエラーを返す
+// DONE: 正常系: Numbers指定で個別Issueを取得する
+// DONE: 正常系: Numbers指定でAPIエラー時にエラーを返す
+
+func TestListIssues_ReturnsIssuesExcludingPRs(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	closedAt := now.Add(-1 * time.Hour)
+
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/issues" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		issues := []*gh.Issue{
+			{
+				Number:    gh.Ptr(1),
+				Title:     gh.Ptr("Test Issue"),
+				State:     gh.Ptr("closed"),
+				User:      &gh.User{Login: gh.Ptr("testuser")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				ClosedAt:  &gh.Timestamp{Time: closedAt},
+				HTMLURL:   gh.Ptr("https://github.com/owner/repo/issues/1"),
+				Labels: []*gh.Label{
+					{Name: gh.Ptr("bug")},
+					{Name: gh.Ptr("help wanted")},
+				},
+			},
+			{
+				// PRはIssuesAPIでも返るので除外されるべき
+				Number:           gh.Ptr(2),
+				Title:            gh.Ptr("Test PR via Issues API"),
+				State:            gh.Ptr("open"),
+				User:             &gh.User{Login: gh.Ptr("pruser")},
+				CreatedAt:        &gh.Timestamp{Time: now},
+				UpdatedAt:        &gh.Timestamp{Time: now},
+				HTMLURL:          gh.Ptr("https://github.com/owner/repo/pull/2"),
+				PullRequestLinks: &gh.PullRequestLinks{URL: gh.Ptr("https://api.github.com/repos/owner/repo/pulls/2")},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(issues)
+	})
+	defer server.Close()
+
+	results, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("got %d issues, want 1 (PR should be excluded)", len(results))
+	}
+
+	issue := results[0]
+	if issue.Number != 1 {
+		t.Errorf("Number = %d, want 1", issue.Number)
+	}
+	if issue.Title != "Test Issue" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Test Issue")
+	}
+	if issue.State != entity.IssueStateClosed {
+		t.Errorf("State = %q, want %q", issue.State, entity.IssueStateClosed)
+	}
+	if issue.Author != "testuser" {
+		t.Errorf("Author = %q, want %q", issue.Author, "testuser")
+	}
+	if issue.ClosedAt == nil {
+		t.Error("ClosedAt should not be nil")
+	}
+	if issue.URL != "https://github.com/owner/repo/issues/1" {
+		t.Errorf("URL = %q, want %q", issue.URL, "https://github.com/owner/repo/issues/1")
+	}
+	if len(issue.Labels) != 2 || issue.Labels[0] != "bug" || issue.Labels[1] != "help wanted" {
+		t.Errorf("Labels = %v, want [bug, help wanted]", issue.Labels)
+	}
+}
+
+func TestListIssues_StatusOpen(t *testing.T) {
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		state := r.URL.Query().Get("state")
+		if state != "open" {
+			t.Errorf("state query param = %q, want %q", state, "open")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*gh.Issue{})
+	})
+	defer server.Close()
+
+	_, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{
+		Status: entity.IssueStateOpen,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListIssues_SinceFilter(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	since := now.Add(-24 * time.Hour)
+	oldTime := now.Add(-72 * time.Hour)
+
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		issues := []*gh.Issue{
+			{
+				Number:    gh.Ptr(1),
+				Title:     gh.Ptr("Recent Issue"),
+				State:     gh.Ptr("open"),
+				User:      &gh.User{Login: gh.Ptr("user1")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				HTMLURL:   gh.Ptr("https://github.com/owner/repo/issues/1"),
+			},
+			{
+				Number:    gh.Ptr(2),
+				Title:     gh.Ptr("Old Issue"),
+				State:     gh.Ptr("open"),
+				User:      &gh.User{Login: gh.Ptr("user2")},
+				CreatedAt: &gh.Timestamp{Time: oldTime},
+				UpdatedAt: &gh.Timestamp{Time: oldTime},
+				HTMLURL:   gh.Ptr("https://github.com/owner/repo/issues/2"),
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(issues)
+	})
+	defer server.Close()
+
+	results, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{
+		Since: &since,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("got %d issues, want 1 (only recent)", len(results))
+	}
+	if results[0].Number != 1 {
+		t.Errorf("expected recent issue #1, got #%d", results[0].Number)
+	}
+}
+
+func TestListIssues_Empty(t *testing.T) {
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]*gh.Issue{})
+	})
+	defer server.Close()
+
+	results, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("got %d issues, want 0", len(results))
+	}
+}
+
+func TestListIssues_APIError(t *testing.T) {
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	_, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{})
+	if err == nil {
+		t.Error("expected error for API failure")
+	}
+}
+
+func TestListIssues_ByNumbers(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Issues.Get は /repos/owner/repo/issues/{number} にアクセスする
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/10":
+			issue := &gh.Issue{
+				Number:    gh.Ptr(10),
+				Title:     gh.Ptr("Issue Ten"),
+				State:     gh.Ptr("open"),
+				User:      &gh.User{Login: gh.Ptr("user1")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				HTMLURL:   gh.Ptr("https://github.com/owner/repo/issues/10"),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(issue)
+		case "/repos/owner/repo/issues/20":
+			issue := &gh.Issue{
+				Number:    gh.Ptr(20),
+				Title:     gh.Ptr("Issue Twenty"),
+				State:     gh.Ptr("closed"),
+				User:      &gh.User{Login: gh.Ptr("user2")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				HTMLURL:   gh.Ptr("https://github.com/owner/repo/issues/20"),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(issue)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer server.Close()
+
+	results, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{
+		Numbers: []int{10, 20},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("got %d issues, want 2", len(results))
+	}
+	if results[0].Number != 10 {
+		t.Errorf("first issue Number = %d, want 10", results[0].Number)
+	}
+	if results[1].Number != 20 {
+		t.Errorf("second issue Number = %d, want 20", results[1].Number)
+	}
+}
+
+func TestListIssues_ByNumbers_APIError(t *testing.T) {
+	c, server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	_, err := c.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{
+		Numbers: []int{999},
+	})
+	if err == nil {
+		t.Error("expected error for API failure")
+	}
+}


### PR DESCRIPTION
## Summary

- domain層にIssueエンティティ（`IssueState`, `Issue`構造体）を定義
- `GitHubRepository`インターフェースに`ListIssues`メソッドを追加
- infra層にIssue一覧取得を実装（ページネーション、Since/Statusフィルタ、PR除外）
- `--issue`フラグ対応: Numbers指定による個別Issue取得

## 成果物

| ファイル | 内容 |
|---------|------|
| `internal/domain/entity/issue.go` | Issueエンティティ定義 |
| `internal/domain/entity/issue_test.go` | エンティティテスト（4件） |
| `internal/domain/github.go` | インターフェース拡張 |
| `internal/domain/github_test.go` | インターフェーステスト追加（2件） |
| `internal/infra/github/issues.go` | Issue一覧取得の実装 |
| `internal/infra/github/issues_test.go` | infra層テスト（7件） |

## Test plan

- [x] `go test ./internal/...` 全テスト通過
- [x] エンティティ: IssueState値、フィールド設定、ClosedAt nil、Labels空
- [x] infra: PR除外、ステータスフィルタ、Sinceフィルタ、空結果、APIエラー、Numbers取得、Numbers APIエラー

Closes #6

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)