### PR TITLE
assign-issues.sh: openのIssueがない場合はClaude呼び出しをスキップ

### DIFF
--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -12,6 +12,13 @@ done
 
 echo "Issue自動選定を開始します"
 
+# openのIssue数を確認し、0件ならスキップ
+OPEN_COUNT=$(gh issue list --state open --json number --jq 'length')
+if [ "$OPEN_COUNT" -eq 0 ]; then
+  echo "open状態のIssueがないため、スキップします"
+  exit 0
+fi
+
 # Claudeでissueを選定・ラベル付与（コード変更不要のため--worktreeは不使用）
 if "${USE_PRINT_MODE}"; then
   claude --dangerously-skip-permissions -p "/assign-issues"


### PR DESCRIPTION
## Summary

- `assign-issues.sh` でClaude呼び出し前にopen状態のIssue数を確認するようにした
- openのIssueが0件の場合、メッセージを表示してスクリプトを正常終了する
- openのIssueが1件以上ある場合のみ、従来通りClaudeを呼び出す

Closes #41

## Test plan

- [ ] openのIssueが0件の状態で `assign-issues.sh` を実行し、Claudeが呼び出されずにスキップメッセージが表示されることを確認
- [ ] openのIssueが1件以上ある状態で `assign-issues.sh` を実行し、従来通りClaudeが呼び出されることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01NcJNymVqD1anwQVhDCKYnC