### PR TITLE
assign-issues.sh: openのIssueがない場合はClaude呼び出しをスキップ #41

### DIFF
--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -12,6 +12,13 @@ done
 
 echo "Issue自動選定を開始します"
 
+# open状態のIssue数を確認し、0件ならスキップ
+OPEN_COUNT=$(gh issue list --state open --json number --jq 'length')
+if [ "$OPEN_COUNT" -eq 0 ]; then
+  echo "open状態のIssueがないため、スキップします"
+  exit 0
+fi
+
 # Claudeでissueを選定・ラベル付与（コード変更不要のため--worktreeは不使用）
 if "${USE_PRINT_MODE}"; then
   claude --dangerously-skip-permissions -p "/assign-issues"


### PR DESCRIPTION
## Summary
- `assign-issues.sh` でClaude呼び出し前にopen状態のIssue数を確認するガードを追加
- openのIssueが0件の場合、メッセージを表示してスクリプトを正常終了し、不要なClaude呼び出しを防止

## Test plan
- [ ] open状態のIssueが0件の場合にスクリプトがスキップメッセージを表示して正常終了することを確認
- [ ] open状態のIssueが1件以上ある場合に従来通りClaude呼び出しが実行されることを確認

Closes #41

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)