### PR TITLE
引数なしで実行した場合にヘルプを表示する #44

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -18,6 +18,10 @@ func defineFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("output", "o", "", "レポート出力先ファイルパス（未指定時は標準出力）")
 }
 
+func noFlagsSpecified(cmd *cobra.Command) bool {
+	return cmd.Flags().NFlag() == 0
+}
+
 func validateFlags(cmd *cobra.Command) error {
 	today, _ := cmd.Flags().GetBool("today")
 	since, _ := cmd.Flags().GetString("since")
@@ -32,11 +36,6 @@ func validateFlags(cmd *cobra.Command) error {
 	// --pr と --issue の同時指定はエラー
 	if pr != 0 && issue != 0 {
 		return fmt.Errorf("--pr と --issue は同時に指定できません")
-	}
-
-	// 対象指定なしはエラー
-	if !today && since == "" && pr == 0 && issue == 0 {
-		return fmt.Errorf("--today, --since, --pr, --issue のいずれかを指定してください")
 	}
 
 	// --since の値が不正な場合エラー

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -23,12 +23,12 @@ func TestValidation_PRAndIssueConflict(t *testing.T) {
 	}
 }
 
-func TestValidation_NoTargetSpecified(t *testing.T) {
+func TestValidation_NoTargetSpecified_NoError(t *testing.T) {
 	cmd := makeRootCmd()
 	_ = cmd.ParseFlags([]string{})
 	err := validateFlags(cmd)
-	if err == nil {
-		t.Error("expected error when no target is specified")
+	if err != nil {
+		t.Errorf("no target specified should not return error from validateFlags, got: %v", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,9 @@ func makeRootCmd() *cobra.Command {
 	cmd.SilenceUsage = true
 	defineFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if noFlagsSpecified(cmd) {
+			return cmd.Help()
+		}
 		if err := validateFlags(cmd); err != nil {
 			return err
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,13 +2,27 @@ package cmd
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
-func TestExecute_NoArgs_ReturnsError(t *testing.T) {
-	err := Execute()
-	if err == nil {
-		t.Fatal("Execute() without args should return error")
+func TestExecute_NoArgs_ShowsHelp(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Execute() without args should not return error, got: %v", err)
+	}
+
+	output := buf.String()
+	if len(output) == 0 {
+		t.Error("expected help output, got empty string")
+	}
+	if !strings.Contains(output, "github-analyzer") {
+		t.Errorf("expected help output to contain 'github-analyzer', got: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- 引数・フラグが一切指定されていない場合、エラーではなくヘルプメッセージを表示して正常終了（終了コード0）するように変更
- `RunE` 内で `cmd.Flags().NFlag() == 0` を判定し、`cmd.Help()` を呼び出す
- `validateFlags` から「対象指定なしはエラー」のチェックを削除

## Test plan

- [x] `TestExecute_NoArgs_ShowsHelp` — 引数なしでヘルプが表示され、エラーが返らないことを確認
- [x] `TestValidation_NoTargetSpecified_NoError` — validateFlagsが対象未指定でもエラーを返さないことを確認
- [x] 既存の全cmdテストがパスすることを確認
- [x] `gofmt` / `golangci-lint` でフォーマット・lint問題なし

Closes #44

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)