### PR TITLE
設定ファイルテンプレ作成のinitコマンドを追加 #48

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/canpok1/github-analyzer/templates"
+	"github.com/spf13/cobra"
+)
+
+func makeInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "設定ファイルのテンプレートを生成する",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			const fileName = ".github-analyzer.yaml"
+			f, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+			if err != nil {
+				if os.IsExist(err) {
+					return fmt.Errorf("%s は既に存在します", fileName)
+				}
+				return err
+			}
+			defer func() { _ = f.Close() }()
+
+			if _, err := f.Write(templates.ConfigTemplate); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s を作成しました\n", fileName)
+			return nil
+		},
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// DONE: 正常系: テンプレートファイルがカレントディレクトリに生成される
+// DONE: 異常系: 既にファイルが存在する場合はエラーになり上書きされない
+// DONE: 正常系: テンプレートに各フィールドのコメント付きサンプルが含まれている
+
+func TestInitCmd_CreatesTemplateFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer os.Chdir(origDir)
+	os.Chdir(dir)
+
+	cmd := makeRootCmd()
+	cmd.SetArgs([]string{"init"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("expected .github-analyzer.yaml to be created, but it does not exist")
+	}
+}
+
+func TestInitCmd_FileAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer os.Chdir(origDir)
+	os.Chdir(dir)
+
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+	originalContent := "original content"
+	if err := os.WriteFile(configPath, []byte(originalContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := makeRootCmd()
+	cmd.SetArgs([]string{"init"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when file already exists, got nil")
+	}
+
+	data, _ := os.ReadFile(configPath)
+	if string(data) != originalContent {
+		t.Errorf("file was overwritten: got %q, want %q", string(data), originalContent)
+	}
+}
+
+func TestInitCmd_TemplateContainsFieldComments(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer os.Chdir(origDir)
+	os.Chdir(dir)
+
+	cmd := makeRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+
+	content := string(data)
+	expectedFields := []string{"repo:", "tone:", "default_prompt:", "model:"}
+	for _, field := range expectedFields {
+		if !strings.Contains(content, field) {
+			t.Errorf("template does not contain field %q", field)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ func makeRootCmd() *cobra.Command {
 		Version: version,
 	}
 	cmd.SilenceUsage = true
+	cmd.AddCommand(makeInitCmd())
 	defineFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if noFlagsSpecified(cmd) {

--- a/templates/.github-analyzer.yaml
+++ b/templates/.github-analyzer.yaml
@@ -1,0 +1,14 @@
+# github-analyzer 設定ファイル
+# 各項目のコメントを解除して値を設定してください。
+
+# 分析対象のGitHubリポジトリ（owner/repo 形式）
+# repo: owner/repo
+
+# 分析レポートのトーン（例: friendly, formal, casual）
+# tone: friendly
+
+# デフォルトの分析プロンプト
+# default_prompt: チームの活動を分析してください
+
+# 使用するGeminiモデル（例: gemini-2.0-flash）
+# model: gemini-2.0-flash

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,0 +1,6 @@
+package templates
+
+import _ "embed"
+
+//go:embed .github-analyzer.yaml
+var ConfigTemplate []byte

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -1,0 +1,20 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigTemplate_ContainsExpectedFields(t *testing.T) {
+	if len(ConfigTemplate) == 0 {
+		t.Fatal("ConfigTemplate is empty")
+	}
+
+	content := string(ConfigTemplate)
+	expectedFields := []string{"repo:", "tone:", "default_prompt:", "model:"}
+	for _, field := range expectedFields {
+		if !strings.Contains(content, field) {
+			t.Errorf("ConfigTemplate does not contain field %q", field)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `github-analyzer init` コマンドを追加し、カレントディレクトリに `.github-analyzer.yaml` テンプレートファイルを生成する機能を実装
- 既にファイルが存在する場合はエラーメッセージを表示し上書きしない
- `//go:embed` でテンプレートファイルをバイナリに埋め込み、`templates/` パッケージとして管理

## 変更ファイル

- `templates/.github-analyzer.yaml` — コメント付きYAMLテンプレート
- `templates/embed.go` — `//go:embed` によるテンプレート埋め込み
- `templates/embed_test.go` — テンプレート埋め込みのテスト
- `cmd/init.go` — `init` サブコマンドの定義
- `cmd/init_test.go` — initコマンドのユニットテスト
- `cmd/root.go` — initサブコマンドの登録

## Test plan

- [x] `github-analyzer init` でテンプレートファイルが生成される
- [x] 既にファイルが存在する場合はエラーになり上書きされない
- [x] テンプレートに各フィールド（repo, tone, default_prompt, model）のコメント付きサンプルが含まれている
- [x] 全既存テストがパスする
- [x] golangci-lint の指摘なし

Closes #48

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)