### PR TITLE
initコマンドのテストで os.Chdir を t.Chdir に置き換え #51

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -13,9 +13,7 @@ import (
 
 func TestInitCmd_CreatesTemplateFile(t *testing.T) {
 	dir := t.TempDir()
-	origDir, _ := os.Getwd()
-	defer os.Chdir(origDir)
-	os.Chdir(dir)
+	t.Chdir(dir)
 
 	cmd := makeRootCmd()
 	cmd.SetArgs([]string{"init"})
@@ -32,9 +30,7 @@ func TestInitCmd_CreatesTemplateFile(t *testing.T) {
 
 func TestInitCmd_FileAlreadyExists(t *testing.T) {
 	dir := t.TempDir()
-	origDir, _ := os.Getwd()
-	defer os.Chdir(origDir)
-	os.Chdir(dir)
+	t.Chdir(dir)
 
 	configPath := filepath.Join(dir, ".github-analyzer.yaml")
 	originalContent := "original content"
@@ -57,9 +53,7 @@ func TestInitCmd_FileAlreadyExists(t *testing.T) {
 
 func TestInitCmd_TemplateContainsFieldComments(t *testing.T) {
 	dir := t.TempDir()
-	origDir, _ := os.Getwd()
-	defer os.Chdir(origDir)
-	os.Chdir(dir)
+	t.Chdir(dir)
 
 	cmd := makeRootCmd()
 	cmd.SetArgs([]string{"init"})


### PR DESCRIPTION
## Summary
- `cmd/init_test.go` の3つのテスト関数で `os.Chdir` / `defer os.Chdir(origDir)` パターンを `t.Chdir` に置き換え
- テスト終了時の自動復元によりコードがシンプルになり、将来的な `t.Parallel()` 対応も容易になる

## Test plan
- [x] `go test ./cmd/ -run TestInitCmd -v` で全3テストがPASSすることを確認済み
- [x] `gofmt -l .` で未フォーマットなし
- [x] `golangci-lint run` で指摘なし

Closes #51

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)