### PR TITLE
Issue選定対象をreadyラベル付きに限定する #53

### DIFF
--- a/.claude/agents/issue-assigner.md
+++ b/.claude/agents/issue-assigner.md
@@ -1,18 +1,18 @@
 ---
 name: issue-assigner
-description: open状態のIssueを優先度順に評価し、上位2件に assign-to-claude ラベルを付与する専用エージェント。
+description: readyラベル付きのopen状態のIssueを優先度順に評価し、上位2件に assign-to-claude ラベルを付与する専用エージェント。
 tools: Bash(gh issue list *), Bash(gh issue view *), Bash(gh issue edit *)
 model: sonnet
 ---
 
 # Issue自動選定エージェント
 
-open状態のIssueを優先度順に評価し、上位2件に `assign-to-claude` ラベルを付与する。
+`ready` ラベルが付いたopen状態のIssueを優先度順に評価し、上位2件に `assign-to-claude` ラベルを付与する。
 
 ## ワークフロー
 
 1. **Issue一覧の取得**
-   - `gh issue list --state open --json number,title,labels,body,createdAt --limit 100` でopen状態のIssue一覧を取得
+   - `gh issue list --state open --label "ready" --json number,title,labels,body,createdAt --limit 100` で `ready` ラベル付きのopen状態のIssue一覧を取得
    - 既に `assign-to-claude` または `in-progress-by-claude` ラベルが付いているIssueは除外
 
 2. **優先度判定**

--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -12,10 +12,10 @@ done
 
 echo "Issue自動選定を開始します"
 
-# open状態のIssue数を確認し、0件ならスキップ
-OPEN_COUNT=$(gh issue list --state open --json number --jq 'length')
-if [ "$OPEN_COUNT" -eq 0 ]; then
-  echo "open状態のIssueがないため、スキップします"
+# readyラベル付きのIssue数を確認し、0件ならスキップ
+READY_COUNT=$(gh issue list --state open --label "ready" --json number --jq 'length')
+if [ "$READY_COUNT" -eq 0 ]; then
+  echo "readyラベル付きのIssueがないため、スキップします"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- `issue-assigner` エージェントの Issue 一覧取得時に `--label "ready"` を追加し、`ready` ラベル付き Issue のみを選定対象に変更
- `assign-issues.sh` の open 件数チェックを `ready` ラベル付き Issue のカウントに変更
- リポジトリに `ready` ラベルを作成

Closes #53

## Test plan
- [ ] `ready` ラベルがリポジトリに作成されていることを確認
- [ ] `assign-issues.sh` で `ready` ラベル付き Issue が 0 件の場合にスキップされることを確認
- [ ] `issue-assigner` エージェントが `ready` ラベル付き Issue のみを取得対象とすることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)