### PR TITLE
.gitignoreにビルド成果物と生成設定ファイルを追加する #55

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ profile.cov
 go.work
 go.work.sum
 
+# Build artifacts
+github-analyzer
+
+# Generated config file
+.github-analyzer.yaml
+
 # env file
 .env
 


### PR DESCRIPTION
## Summary
- `make build`で生成されるバイナリ(`github-analyzer`)を`.gitignore`に追加
- `github-analyzer init`で生成される設定ファイル(`.github-analyzer.yaml`)を`.gitignore`に追加

Closes #55

## Test plan
- [ ] `.gitignore`の差分が意図通りであること
- [ ] 既存のエントリが影響を受けていないこと

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)