### PR TITLE
設定ファイルによるGemini API / GitHub APIのモック機能の追加 #57

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,12 @@ import (
 	"os"
 
 	"github.com/canpok1/github-analyzer/internal/app"
+	"github.com/canpok1/github-analyzer/internal/domain"
 	"github.com/canpok1/github-analyzer/internal/infra/config"
 	"github.com/canpok1/github-analyzer/internal/infra/gemini"
 	ghclient "github.com/canpok1/github-analyzer/internal/infra/github"
+	applog "github.com/canpok1/github-analyzer/internal/infra/log"
+	"github.com/canpok1/github-analyzer/internal/infra/mock"
 	"github.com/canpok1/github-analyzer/internal/infra/report"
 	"github.com/spf13/cobra"
 )
@@ -41,16 +44,6 @@ func Execute() error {
 
 // runAnalyze はDIを行い、app.Analyzeを実行する。
 func runAnalyze(cmd *cobra.Command) error {
-	token, err := resolveToken()
-	if err != nil {
-		return err
-	}
-
-	geminiAPIKey := os.Getenv("GEMINI_API_KEY")
-	if geminiAPIKey == "" {
-		return fmt.Errorf("GEMINI_API_KEY 環境変数を設定してください")
-	}
-
 	query := buildQuery(cmd)
 
 	cfg, err := config.Load()
@@ -60,25 +53,61 @@ func runAnalyze(cmd *cobra.Command) error {
 
 	query = applyConfig(query, cfg)
 
-	ghClient := ghclient.NewClient(token)
-	geminiClient, err := gemini.NewClient(geminiAPIKey)
-	if err != nil {
-		return err
+	// GitHubRepository の解決
+	var ghRepo domain.GitHubRepository
+	if cfg.Mock.Repository {
+		ghRepo = &mock.GitHubRepository{}
+	} else {
+		token, err := resolveToken()
+		if err != nil {
+			return err
+		}
+		ghRepo = ghclient.NewClient(token)
 	}
-	geminiClient.SetModel(query.Model)
+
+	// Analyzer の解決
+	var analyzer domain.Analyzer
+	if cfg.Mock.AI {
+		analyzer = &mock.Analyzer{}
+	} else {
+		geminiAPIKey := os.Getenv("GEMINI_API_KEY")
+		if geminiAPIKey == "" {
+			return fmt.Errorf("GEMINI_API_KEY 環境変数を設定してください")
+		}
+		geminiClient, err := gemini.NewClient(geminiAPIKey)
+		if err != nil {
+			return err
+		}
+		geminiClient.SetModel(query.Model)
+		analyzer = geminiClient
+	}
+
+	// Logger の解決
+	var logger app.LogFunc
+	if cfg.LogFile != "" {
+		logWriter, err := applog.NewFileWriter(cfg.LogFile)
+		if err != nil {
+			return fmt.Errorf("ログファイルの作成に失敗しました: %w", err)
+		}
+		defer func() { _ = logWriter.Close() }()
+		logger = func(msg string) {
+			_ = logWriter.Write(msg)
+		}
+	}
 
 	outputPath, _ := cmd.Flags().GetString("output")
 	renderer := report.NewMarkdownRenderer()
 	writer := report.NewWriter(outputPath, cmd.OutOrStdout())
 
 	deps := app.AnalyzeDeps{
-		GitHubRepo:    ghClient,
-		Analyzer:      geminiClient,
+		GitHubRepo:    ghRepo,
+		Analyzer:      analyzer,
 		PromptBuilder: gemini.BuildPrompt,
 		ReportParser:  gemini.ParseReport,
 		Renderer:      renderer,
 		Writer:        writer,
 		Stderr:        os.Stderr,
+		Logger:        logger,
 	}
 
 	return app.Analyze(cmd.Context(), deps, query)

--- a/internal/app/analyze.go
+++ b/internal/app/analyze.go
@@ -15,6 +15,9 @@ type PromptBuilderFunc func(data *CollectedData, userPrompt string) domain.Analy
 // ReportParserFunc はAI分析結果のテキストをReportエンティティにパースする関数型。
 type ReportParserFunc func(content string) (*entity.Report, error)
 
+// LogFunc はログメッセージを書き込む関数型。nilの場合はログ出力しない。
+type LogFunc func(message string)
+
 // AnalyzeDeps はAnalyze関数の依存をまとめた構造体。
 type AnalyzeDeps struct {
 	GitHubRepo    domain.GitHubRepository
@@ -24,6 +27,7 @@ type AnalyzeDeps struct {
 	Renderer      domain.ReportRenderer
 	Writer        domain.ReportWriter
 	Stderr        io.Writer
+	Logger        LogFunc
 }
 
 // printProgress はstderrに進捗メッセージを出力する。
@@ -43,6 +47,12 @@ func Analyze(ctx context.Context, deps AnalyzeDeps, query entity.Query) error {
 	printProgress(deps.Stderr, "AI分析を実行中...")
 
 	req := deps.PromptBuilder(data, query.Prompt)
+
+	if deps.Logger != nil {
+		deps.Logger(fmt.Sprintf("=== Prompt ===\n%s", req.Prompt))
+		deps.Logger(fmt.Sprintf("=== Data ===\n%s", req.Data))
+	}
+
 	resp, err := deps.Analyzer.Analyze(ctx, req)
 	if err != nil {
 		return fmt.Errorf("AI分析に失敗しました: %w", err)

--- a/internal/app/analyze_test.go
+++ b/internal/app/analyze_test.go
@@ -205,6 +205,49 @@ func TestAnalyze_WriterError(t *testing.T) {
 	}
 }
 
+func TestAnalyze_LoggerReceivesPromptAndData(t *testing.T) {
+	deps, _ := newSuccessDeps()
+	var logged []string
+	deps.Logger = func(msg string) {
+		logged = append(logged, msg)
+	}
+	deps.PromptBuilder = func(_ *CollectedData, _ string) domain.AnalysisRequest {
+		return domain.AnalysisRequest{Prompt: "test-prompt", Data: "test-data"}
+	}
+	query := entity.Query{
+		Repo: "owner/repo",
+		PR:   intPtr(1),
+	}
+
+	err := Analyze(context.Background(), deps, query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(logged) < 2 {
+		t.Fatalf("expected at least 2 log entries, got %d", len(logged))
+	}
+	if !strings.Contains(logged[0], "test-prompt") {
+		t.Errorf("first log should contain prompt, got %q", logged[0])
+	}
+	if !strings.Contains(logged[1], "test-data") {
+		t.Errorf("second log should contain data, got %q", logged[1])
+	}
+}
+
+func TestAnalyze_NilLoggerDoesNotPanic(t *testing.T) {
+	deps, _ := newSuccessDeps()
+	deps.Logger = nil
+	query := entity.Query{
+		Repo: "owner/repo",
+		PR:   intPtr(1),
+	}
+
+	err := Analyze(context.Background(), deps, query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func intPtr(v int) *int {
 	return &v
 }

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -1,9 +1,17 @@
 package entity
 
+// MockConfig はモック設定を表す。
+type MockConfig struct {
+	AI         bool `yaml:"ai"`
+	Repository bool `yaml:"repository"`
+}
+
 // Config は設定ファイルの内容を表す。
 type Config struct {
-	Repo          string `yaml:"repo"`
-	Tone          string `yaml:"tone"`
-	DefaultPrompt string `yaml:"default_prompt"`
-	Model         string `yaml:"model"`
+	Repo          string     `yaml:"repo"`
+	Tone          string     `yaml:"tone"`
+	DefaultPrompt string     `yaml:"default_prompt"`
+	Model         string     `yaml:"model"`
+	Mock          MockConfig `yaml:"mock"`
+	LogFile       string     `yaml:"log_file"`
 }

--- a/internal/infra/config/file_test.go
+++ b/internal/infra/config/file_test.go
@@ -149,6 +149,84 @@ func TestLoad_UsesHomeDir(t *testing.T) {
 	}
 }
 
+func TestLoadFromPath_MockConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+
+	content := `mock:
+  ai: true
+  repository: true
+log_file: /tmp/test.log
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromPath(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.Mock.AI {
+		t.Error("Mock.AI should be true")
+	}
+	if !cfg.Mock.Repository {
+		t.Error("Mock.Repository should be true")
+	}
+	if cfg.LogFile != "/tmp/test.log" {
+		t.Errorf("LogFile = %q, want %q", cfg.LogFile, "/tmp/test.log")
+	}
+}
+
+func TestLoadFromPath_MockDefaults(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+
+	content := `repo: owner/repo`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromPath(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Mock.AI {
+		t.Error("Mock.AI should default to false")
+	}
+	if cfg.Mock.Repository {
+		t.Error("Mock.Repository should default to false")
+	}
+	if cfg.LogFile != "" {
+		t.Errorf("LogFile should default to empty, got %q", cfg.LogFile)
+	}
+}
+
+func TestLoadFromPath_PartialMock(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".github-analyzer.yaml")
+
+	content := `mock:
+  ai: true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromPath(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.Mock.AI {
+		t.Error("Mock.AI should be true")
+	}
+	if cfg.Mock.Repository {
+		t.Error("Mock.Repository should be false when not specified")
+	}
+}
+
 func TestLoad_NoConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/internal/infra/log/writer.go
+++ b/internal/infra/log/writer.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// FileWriter はファイルにログを書き込む実装。
+type FileWriter struct {
+	file *os.File
+}
+
+// NewFileWriter は指定パスにログファイルを作成する。
+func NewFileWriter(path string) (*FileWriter, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("ログファイルを開けません: %w", err)
+	}
+	return &FileWriter{file: f}, nil
+}
+
+func (w *FileWriter) Write(message string) error {
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	_, err := fmt.Fprintf(w.file, "[%s] %s\n", timestamp, message)
+	return err
+}
+
+func (w *FileWriter) Close() error {
+	return w.file.Close()
+}

--- a/internal/infra/log/writer_test.go
+++ b/internal/infra/log/writer_test.go
@@ -1,0 +1,55 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileWriter_Write(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewFileWriter(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer w.Close()
+
+	err = w.Write("test message")
+	if err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if !strings.Contains(string(data), "test message") {
+		t.Errorf("log file should contain 'test message', got %q", string(data))
+	}
+}
+
+func TestFileWriter_WriteMultiple(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := NewFileWriter(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer w.Close()
+
+	_ = w.Write("first")
+	_ = w.Write("second")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "first") || !strings.Contains(content, "second") {
+		t.Errorf("log file should contain both messages, got %q", content)
+	}
+}

--- a/internal/infra/mock/analyzer.go
+++ b/internal/infra/mock/analyzer.go
@@ -1,0 +1,29 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+)
+
+const dummyReport = `## Overview
+[Mock] チーム全体として安定した開発ペースを維持しており、活発な議論と着実なマージが行われています。
+
+## Process Insights
+モックモードで実行されているため、実際のデータに基づく分析は行われていません。実データでの分析を行うには、設定ファイルの mock.ai を false に変更してください。
+
+## Potential Risks
+モックモードのため、実際のリスク分析は行われていません。
+
+## Manager's Hint
+モックモードでの動作確認が完了したら、実際のAPIキーを設定して本番の分析を実行してください。`
+
+// Analyzer は domain.Analyzer のモック実装。
+// 固定のダミーレポートを返す。
+type Analyzer struct{}
+
+func (a *Analyzer) Analyze(_ context.Context, _ domain.AnalysisRequest) (*domain.AnalysisResponse, error) {
+	return &domain.AnalysisResponse{
+		Content: dummyReport,
+	}, nil
+}

--- a/internal/infra/mock/analyzer_test.go
+++ b/internal/infra/mock/analyzer_test.go
@@ -1,0 +1,48 @@
+package mock
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+)
+
+func TestAnalyzer_Analyze(t *testing.T) {
+	analyzer := &Analyzer{}
+	resp, err := analyzer.Analyze(context.Background(), domain.AnalysisRequest{
+		Prompt: "test prompt",
+		Data:   "test data",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("response should not be nil")
+	}
+	if resp.Content == "" {
+		t.Error("response content should not be empty")
+	}
+}
+
+func TestAnalyzer_ReportContainsAllSections(t *testing.T) {
+	analyzer := &Analyzer{}
+	resp, err := analyzer.Analyze(context.Background(), domain.AnalysisRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sections := []string{
+		"## Overview",
+		"## Process Insights",
+		"## Potential Risks",
+		"## Manager's Hint",
+	}
+	for _, section := range sections {
+		if !strings.Contains(resp.Content, section) {
+			t.Errorf("response should contain %q", section)
+		}
+	}
+}

--- a/internal/infra/mock/github.go
+++ b/internal/infra/mock/github.go
@@ -1,0 +1,111 @@
+package mock
+
+import (
+	"context"
+	"time"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+	"github.com/canpok1/github-analyzer/internal/domain/entity"
+)
+
+var baseTime = time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)
+
+// GitHubRepository は domain.GitHubRepository のモック実装。
+// 固定のダミーデータを返す。
+type GitHubRepository struct{}
+
+func (r *GitHubRepository) ListPullRequests(_ context.Context, _, _ string, _ domain.ListPullRequestsOptions) ([]entity.PullRequest, error) {
+	mergedAt := baseTime.Add(48 * time.Hour)
+	return []entity.PullRequest{
+		{
+			Number:    1,
+			Title:     "[Mock] 機能追加のPR",
+			State:     entity.PRStateMerged,
+			Author:    "mock-user",
+			CreatedAt: baseTime,
+			UpdatedAt: baseTime.Add(24 * time.Hour),
+			MergedAt:  &mergedAt,
+			URL:       "https://github.com/example/repo/pull/1",
+		},
+		{
+			Number:    2,
+			Title:     "[Mock] バグ修正のPR",
+			State:     entity.PRStateOpen,
+			Author:    "mock-reviewer",
+			CreatedAt: baseTime.Add(72 * time.Hour),
+			UpdatedAt: baseTime.Add(96 * time.Hour),
+			URL:       "https://github.com/example/repo/pull/2",
+		},
+	}, nil
+}
+
+func (r *GitHubRepository) ListIssues(_ context.Context, _, _ string, _ domain.ListIssuesOptions) ([]entity.Issue, error) {
+	closedAt := baseTime.Add(72 * time.Hour)
+	return []entity.Issue{
+		{
+			Number:    10,
+			Title:     "[Mock] 機能要望",
+			State:     entity.IssueStateClosed,
+			Author:    "mock-user",
+			CreatedAt: baseTime,
+			UpdatedAt: baseTime.Add(48 * time.Hour),
+			ClosedAt:  &closedAt,
+			URL:       "https://github.com/example/repo/issues/10",
+			Labels:    []string{"enhancement"},
+		},
+		{
+			Number:    11,
+			Title:     "[Mock] バグ報告",
+			State:     entity.IssueStateOpen,
+			Author:    "mock-reporter",
+			CreatedAt: baseTime.Add(24 * time.Hour),
+			UpdatedAt: baseTime.Add(48 * time.Hour),
+			URL:       "https://github.com/example/repo/issues/11",
+			Labels:    []string{"bug"},
+		},
+	}, nil
+}
+
+func (r *GitHubRepository) ListIssueComments(_ context.Context, _, _ string, _ int) ([]entity.Comment, error) {
+	return []entity.Comment{
+		{
+			ID:        1,
+			Body:      "[Mock] 対応方針について確認しました。",
+			Author:    "mock-reviewer",
+			CreatedAt: baseTime.Add(2 * time.Hour),
+			Type:      entity.CommentTypeIssue,
+		},
+	}, nil
+}
+
+func (r *GitHubRepository) ListPullRequestComments(_ context.Context, _, _ string, _ int) ([]entity.Comment, error) {
+	return []entity.Comment{
+		{
+			ID:        2,
+			Body:      "[Mock] コードレビューコメントです。",
+			Author:    "mock-reviewer",
+			CreatedAt: baseTime.Add(26 * time.Hour),
+			Type:      entity.CommentTypeReview,
+			Path:      "main.go",
+		},
+	}, nil
+}
+
+func (r *GitHubRepository) ListTimelineEvents(_ context.Context, _, _ string, _ int) ([]entity.TimelineEvent, error) {
+	return []entity.TimelineEvent{
+		{
+			ID:        1,
+			Event:     "labeled",
+			Actor:     "mock-user",
+			CreatedAt: baseTime.Add(1 * time.Hour),
+			Label:     "enhancement",
+		},
+		{
+			ID:        2,
+			Event:     "assigned",
+			Actor:     "mock-user",
+			CreatedAt: baseTime.Add(1 * time.Hour),
+			Assignee:  "mock-developer",
+		},
+	}, nil
+}

--- a/internal/infra/mock/github_test.go
+++ b/internal/infra/mock/github_test.go
@@ -1,0 +1,87 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canpok1/github-analyzer/internal/domain"
+)
+
+func TestGitHubRepository_ListPullRequests(t *testing.T) {
+	repo := &GitHubRepository{}
+	prs, err := repo.ListPullRequests(context.Background(), "owner", "repo", domain.ListPullRequestsOptions{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prs) == 0 {
+		t.Error("should return at least one pull request")
+	}
+	for _, pr := range prs {
+		if pr.Number == 0 {
+			t.Error("PR number should not be zero")
+		}
+		if pr.Title == "" {
+			t.Error("PR title should not be empty")
+		}
+		if pr.Author == "" {
+			t.Error("PR author should not be empty")
+		}
+	}
+}
+
+func TestGitHubRepository_ListIssues(t *testing.T) {
+	repo := &GitHubRepository{}
+	issues, err := repo.ListIssues(context.Background(), "owner", "repo", domain.ListIssuesOptions{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Error("should return at least one issue")
+	}
+	for _, issue := range issues {
+		if issue.Number == 0 {
+			t.Error("Issue number should not be zero")
+		}
+		if issue.Title == "" {
+			t.Error("Issue title should not be empty")
+		}
+	}
+}
+
+func TestGitHubRepository_ListIssueComments(t *testing.T) {
+	repo := &GitHubRepository{}
+	comments, err := repo.ListIssueComments(context.Background(), "owner", "repo", 1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) == 0 {
+		t.Error("should return at least one comment")
+	}
+}
+
+func TestGitHubRepository_ListPullRequestComments(t *testing.T) {
+	repo := &GitHubRepository{}
+	comments, err := repo.ListPullRequestComments(context.Background(), "owner", "repo", 1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) == 0 {
+		t.Error("should return at least one comment")
+	}
+}
+
+func TestGitHubRepository_ListTimelineEvents(t *testing.T) {
+	repo := &GitHubRepository{}
+	events, err := repo.ListTimelineEvents(context.Background(), "owner", "repo", 1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("should return at least one event")
+	}
+}

--- a/templates/.github-analyzer.yaml
+++ b/templates/.github-analyzer.yaml
@@ -12,3 +12,13 @@
 
 # 使用するGeminiモデル（例: gemini-2.0-flash）
 # model: gemini-2.0-flash
+
+# モック設定
+# 実際のAPIにアクセスせずにCLIの動作確認ができます
+# mock:
+#   ai: true           # AI API（Gemini）をモック化（デフォルト: false）
+#   repository: true   # リポジトリAPI（GitHub）をモック化（デフォルト: false）
+
+# ログ設定
+# AI APIに送信されるプロンプト等をログファイルに出力します
+# log_file: /path/to/github-analyzer.log


### PR DESCRIPTION
## Summary

- 設定ファイル（`~/.github-analyzer.yaml`）の `mock` セクションでAI API / リポジトリAPIの個別モック ON/OFF を実現
- `mock.ai: true` で固定ダミーレポートを返すMockAnalyzerに切り替え（APIキー不要）
- `mock.repository: true` で固定ダミーデータを返すMockGitHubRepositoryに切り替え（トークン不要）
- `log_file` 設定でプロンプト内容をログファイルに出力する機能を追加（モック有無に関わらず利用可能）
- 設定ファイルテンプレートにモック設定・ログ設定のコメントを追加

## Test plan

- [x] MockAnalyzerが全セクション含むダミーレポートを返すことを確認するテスト
- [x] MockGitHubRepositoryが全メソッドでダミーデータを返すことを確認するテスト
- [x] FileWriterがログファイルに書き込めることを確認するテスト
- [x] config LoadFromPathでmock/log_file設定を正しく読み込めることを確認するテスト
- [x] app.AnalyzeでLoggerにプロンプト・データが渡されることを確認するテスト
- [x] app.AnalyzeでLogger=nilでもpanicしないことを確認するテスト
- [x] golangci-lint / gofmt チェック通過

Closes #57

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ファイルロギング機能を追加しました。`log_file` 設定で分析プロセスのログを記録できます。
  * モックモードのサポートを追加しました。開発およびテスト時に GitHub API と AI サービスをモック実装に置き換えられます。

* **Chores**
  * 設定テンプレートを更新し、モックおよびロギングオプションの例を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->