### PR TITLE
開発者向けドキュメントをdocs/配下に整備する #69

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+# アーキテクチャ
+
+## ディレクトリ構成
+
+```
+.
+├── cmd/                  # CLIエントリーポイント（DI担当）
+├── internal/
+│   ├── domain/           # ドメイン層
+│   │   └── entity/       # エンティティ定義
+│   ├── app/              # アプリケーション層（ユースケース）
+│   └── infra/            # インフラストラクチャ層
+│       ├── config/       # 設定ファイル読み込み
+│       ├── gemini/       # Gemini APIクライアント
+│       ├── github/       # GitHub APIクライアント
+│       ├── log/          # ログ
+│       ├── mock/         # モック
+│       └── report/       # レポート出力
+├── scripts/              # ユーティリティスクリプト
+├── templates/            # テンプレートファイル
+└── test/
+    └── e2e/              # E2Eテスト
+```
+
+## クリーンアーキテクチャ
+
+本プロジェクトはクリーンアーキテクチャに基づき、以下の4層で構成されています。
+
+### 各層の責務
+
+| 層 | パッケージ | 責務 |
+|---|---|---|
+| domain | `internal/domain/`, `internal/domain/entity/` | エンティティ定義、インターフェース定義。外部への依存を持たない |
+| app | `internal/app/` | ユースケースの実装。domain層のみに依存する |
+| infra | `internal/infra/` | 外部サービスとの通信、I/O処理。domain層・app層に依存できる |
+| cmd | `cmd/` | CLIのエントリーポイント、DI（依存性注入）。全ての層に依存できる |
+
+### 依存関係ルール
+
+内側の層は外側の層に依存してはいけません。
+
+```
+cmd → infra → app → domain
+(外側)                (内側)
+```
+
+具体的な禁止ルール:
+
+- **domain層** → infra層・cmd層への依存禁止
+- **app層** → infra層・cmd層への依存禁止
+- **infra層** → cmd層への依存禁止
+
+これらのルールは `depcheck.yml` で定義されており、`make depcheck` で自動検証できます。

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,0 +1,69 @@
+# 開発ガイド
+
+## 前提条件
+
+- Go（バージョンは `go.mod` を参照）
+
+## セットアップ
+
+開発に必要なツール（golangci-lint, go-depcheck）をインストールします。
+
+```bash
+make setup
+```
+
+## ビルド
+
+```bash
+make build
+```
+
+実行バイナリ `github-analyzer` がプロジェクトルートに生成されます。
+
+### クリーン
+
+```bash
+make clean
+```
+
+ビルド成果物を削除します。
+
+## テスト
+
+### ユニットテスト
+
+```bash
+make test
+```
+
+### E2Eテスト
+
+E2Eテストにはビルドタグ `e2e` が付与されており、通常のテストとは分離されています。
+
+```bash
+make test-e2e
+```
+
+## コード品質
+
+### フォーマット
+
+```bash
+make fmt
+```
+
+### lint
+
+```bash
+make lint
+```
+
+[golangci-lint](https://golangci-lint.run/) を使用しています。
+
+### 依存関係チェック
+
+```bash
+make depcheck
+```
+
+[go-depcheck](https://github.com/v-standard/go-depcheck) を使用して、クリーンアーキテクチャの層間依存ルールを検証します。ルールは `depcheck.yml` に定義されています。詳細は [architecture.md](./architecture.md) を参照してください。


### PR DESCRIPTION
## Summary

- `docs/development-guide.md` を新規作成: 開発環境のセットアップ、ビルド・テスト・lint の実行方法を記載
- `docs/architecture.md` を新規作成: ディレクトリ構成、クリーンアーキテクチャの各層の責務と依存関係ルールを記載

Closes #69

## Test plan

- [ ] `docs/development-guide.md` の内容が Makefile のターゲットと一致していること
- [ ] `docs/architecture.md` のディレクトリ構成が実際の構成と一致していること
- [ ] `docs/architecture.md` の依存関係ルールが `depcheck.yml` と一致していること

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)