### PR TITLE
solve-issueスキルでAIレビューが0件の場合にrate limit待機を追加する #76

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -23,11 +23,12 @@ GitHub Issue $ARGUMENTS を対応します。
   - コマンド: `gh pr checks {PR番号} --watch`
 8. AIレビュワーのrate limitチェックを行う
   - PRのコメントおよびレビュー本文を確認し、AIレビューの有無と `rate limit` 通知をチェックする
-    - コメント: `gh pr view {PR番号} --json comments --jq '.comments[].body'`
-    - レビュー本文: `gh pr view {PR番号} --json reviews --jq '.reviews[].body'`
-    - 以前の `rate limit` コメントが残っていても、その後に正常なAIレビュー完了が確認できる場合は未検出として扱う（投稿時刻で判断する）
+    - コメント: `gh pr view {PR番号} --json comments --jq '.comments[] | select(.author.login=="coderabbitai") | {body: .body, createdAt: .createdAt}'`
+    - レビュー本文: `gh pr view {PR番号} --json reviews --jq '.reviews[] | select(.author.login=="coderabbitai") | {body: .body, submittedAt: .submittedAt}'`
+    - AIレビューの判定基準: 投稿者が `coderabbitai` であるコメント・レビューをAIレビューとしてカウントする
+    - 以前の `rate limit` コメントが残っていても、その後に正常なAIレビュー完了が確認できる場合は未検出として扱う（rate limitコメントの `createdAt` より新しいAIレビューが存在するかで判断する）
   - AIレビューのコメント・レビューが**1件も存在しない**場合:
-    1. 60秒待機してから再度コメント・レビューをチェックする
+    1. 60秒待機してから、上記と同じコマンドで再度コメント・レビューをチェックする
     2. 待機後もAIレビューが0件の場合は、rate limitが原因と見なして以下のrate limit対応フローに入る
   - 現在も有効なrate limitコメントが検出された場合:
     1. コメントの内容を読み取り、待機時間や再レビュー方法を把握する


### PR DESCRIPTION
## Summary
- solve-issueスキルの手順8を拡張し、CIチェック完了後にAIレビューのコメント・レビューが1件も存在しない場合の対応フローを追加
- 60秒待機して再チェックし、それでも0件ならrate limit対応フローに入るよう変更
- PR #74 でAIレビューなしにマージされた問題の再発を防止

## Test plan
- [ ] SKILL.mdの手順8の記述が正しいことを確認
- [ ] 既存の手順（rate limitコメント検出時のフロー）が維持されていることを確認

Closes #76

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * AIレビューの検出ロジックと レート制限通知の処理を改善しました。AIレビューの有無を確認した後、必要に応じて待機と再確認を行うようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->